### PR TITLE
FullWidthImage inside a view with alignItems: 'center' not showing

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 */
 
 import React, { Component } from 'react'
-import { View, Image } from 'react-native'
+import { View, Image, StyleSheet } from 'react-native'
 
 export default class FullWidthImage extends Component {
     constructor(props) {
@@ -47,7 +47,11 @@ export default class FullWidthImage extends Component {
 
     render() {
         return (
-            <View ref={component => this._root = component} onLayout={this._onLayout.bind(this)}>
+            <View
+                ref={component => this._root = component}
+                onLayout={this._onLayout.bind(this)}
+                style={styles.container}
+            >
                 <Image
                     source={this.props.source}
                     style={[this.props.style, {
@@ -59,3 +63,9 @@ export default class FullWidthImage extends Component {
         )
     }
 }
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'stretch'
+  }
+});


### PR DESCRIPTION
When you place the `FullWidthImage` inside a container with `alignItems: 'center'`, the `View` container has 0 width and image is not showing. As you can't pass any styles to the `View` container, the only solution is to wrap the `FullWidthImage` in another `View` that has `alignSelf: 'stretch'` (or `width: '100%'`) and `alignItems` other value than `'center'`.
I propose to add `alignSelf: 'stretch'` to the container so `FullWidthImage` takes full width of its container even if it has `alignItems: 'center'`. I assume it only makes sense to use `FullWidthImage` inside a parent component with `flexDirection: 'column'`. Please correct me if I'm wrong. Otherwise we can probably use `width: '100%'` instead of `alignSelf: 'stretch'`.

Expo snack reproducing the issue: https://snack.expo.io/HJyXgNx0f